### PR TITLE
Fix for removeurls

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Item/Attribute.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Item/Attribute.php
@@ -52,6 +52,12 @@ class Attribute extends \Magento\Catalog\Model\Layer\Filter\Item
             }
 
             $query = [$this->getFilter()->getRequestVar() => $resetValue];
+            
+            foreach ($query as &$item) {
+                if (is_array($item)) {
+                    $item = array_values($item);
+                }
+            }
         }
 
         $params = [


### PR DESCRIPTION
When 3 or more filters are present, it'll result in [0] and [2] inside the $item on the 2nd remove url, giving a result of 0 products
in these cases it should reset the array keys